### PR TITLE
Add configurable status bar visibility

### DIFF
--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -1251,6 +1251,8 @@
   },
   // Status bar-related settings.
   "status_bar": {
+    // Whether to show the status bar.
+    "enabled": true,
     // Whether to show the active language button in the status bar.
     "active_language_button": true
   },

--- a/crates/workspace/src/status_bar.rs
+++ b/crates/workspace/src/status_bar.rs
@@ -1,4 +1,4 @@
-use crate::{ItemHandle, Pane};
+use crate::{ItemHandle, Pane, workspace_settings::StatusBarSettings};
 use gpui::{
     AnyView, App, Context, Decorations, Entity, IntoElement, ParentElement, Render, Styled,
     Subscription, Window,
@@ -37,6 +37,10 @@ pub struct StatusBar {
 
 impl Render for StatusBar {
     fn render(&mut self, window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
+        if !StatusBarSettings::get_global(cx).enabled {
+            return div();
+        }
+
         h_flex()
             .w_full()
             .justify_between()

--- a/crates/workspace/src/workspace.rs
+++ b/crates/workspace/src/workspace.rs
@@ -107,7 +107,8 @@ use ui::{Window, prelude::*};
 use util::{ResultExt, TryFutureExt, paths::SanitizedPath, serde::default_true};
 use uuid::Uuid;
 pub use workspace_settings::{
-    AutosaveSetting, BottomDockLayout, RestoreOnStartupBehavior, TabBarSettings, WorkspaceSettings,
+    AutosaveSetting, BottomDockLayout, RestoreOnStartupBehavior, StatusBarSettings, TabBarSettings,
+    WorkspaceSettings,
 };
 use zed_actions::{Spawn, feedback::FileBugReport};
 
@@ -514,6 +515,7 @@ pub fn init_settings(cx: &mut App) {
     ItemSettings::register(cx);
     PreviewTabsSettings::register(cx);
     TabBarSettings::register(cx);
+    StatusBarSettings::register(cx);
 }
 
 fn prompt_and_open_paths(app_state: Arc<AppState>, options: PathPromptOptions, cx: &mut App) {

--- a/crates/workspace/src/workspace_settings.rs
+++ b/crates/workspace/src/workspace_settings.rs
@@ -205,6 +205,19 @@ pub struct WorkspaceSettingsContent {
 }
 
 #[derive(Deserialize)]
+pub struct StatusBarSettings {
+    pub enabled: bool,
+}
+
+#[derive(Clone, Default, Serialize, Deserialize, JsonSchema)]
+pub struct StatusBarSettingsContent {
+    /// Whether or not to show the status bar.
+    ///
+    /// Default: true
+    pub enabled: Option<bool>,
+}
+
+#[derive(Deserialize)]
 pub struct TabBarSettings {
     pub show: bool,
     pub show_nav_history_buttons: bool,
@@ -360,6 +373,18 @@ impl Settings for WorkspaceSettings {
         // there doesn't seem to be a way to read whether the bottom dock's "justified"
         // setting is enabled in vscode. that'd be our equivalent to "bottom_dock_layout"
     }
+}
+
+impl Settings for StatusBarSettings {
+    const KEY: Option<&'static str> = Some("status_bar");
+
+    type FileContent = StatusBarSettingsContent;
+
+    fn load(sources: SettingsSources<Self::FileContent>, _: &mut App) -> Result<Self> {
+        sources.json_merge()
+    }
+
+    fn import_from_vscode(_vscode: &settings::VsCodeSettings, _current: &mut Self::FileContent) {}
 }
 
 impl Settings for TabBarSettings {

--- a/docs/src/configuring-zed.md
+++ b/docs/src/configuring-zed.md
@@ -1283,9 +1283,15 @@ Each option controls displaying of a particular toolbar element. If all elements
 
 ```json
 "status_bar": {
+  "enabled": true,
   "active_language_button": true,
 },
 ```
+
+**Options**
+
+- `enabled` — Whether to show the status bar. Default: `true`
+- `active_language_button` — Whether to show the active language button in the status bar. Default: `true`
 
 ## LSP
 

--- a/docs/src/visual-customization.md
+++ b/docs/src/visual-customization.md
@@ -310,6 +310,9 @@ TBD: Centered layout related settings
 
 ```json
   "status_bar": {
+    // Show/hide the status bar.
+    // Defaults to true.
+    "enabled": true,
     // Show/hide a button that displays the active buffer's language.
     // Clicking the button brings up the language selector.
     // Defaults to true.


### PR DESCRIPTION
## Summary
- add `StatusBarSettings` and expose `status_bar.enabled` flag
- skip status bar rendering when disabled
- document `status_bar.enabled` and set default to true

## Testing
- `cargo test -p workspace -p editor --no-run` *(compilation in progress; build too heavy to finish)*

------
https://chatgpt.com/codex/tasks/task_e_689a8e87019c832885ea1bcf8a8f7aec