### PR TITLE
Add setting to disable title bar

### DIFF
--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -353,6 +353,8 @@
   },
   // Titlebar related settings
   "title_bar": {
+    // Whether to show the title bar.
+    "enabled": true,
     // Whether to show the branch icon beside branch switcher in the titlebar.
     "show_branch_icon": false,
     // Whether to show the branch name button in the titlebar.

--- a/crates/title_bar/src/title_bar.rs
+++ b/crates/title_bar/src/title_bar.rs
@@ -138,6 +138,11 @@ impl Render for TitleBar {
     fn render(&mut self, window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
         let title_bar_settings = *TitleBarSettings::get_global(cx);
 
+        if !title_bar_settings.enabled {
+            self.platform_titlebar.update(cx, |this, _| this.set_children(Vec::new()));
+            return self.platform_titlebar.clone().into_any_element();
+        }
+
         let show_menus = show_menus(cx);
 
         let mut children = Vec::new();

--- a/crates/title_bar/src/title_bar_settings.rs
+++ b/crates/title_bar/src/title_bar_settings.rs
@@ -5,6 +5,7 @@ use settings::{Settings, SettingsSources};
 
 #[derive(Copy, Clone, Deserialize, Debug)]
 pub struct TitleBarSettings {
+    pub enabled: bool,
     pub show_branch_icon: bool,
     pub show_onboarding_banner: bool,
     pub show_user_picture: bool,
@@ -16,6 +17,10 @@ pub struct TitleBarSettings {
 
 #[derive(Copy, Clone, Default, Serialize, Deserialize, JsonSchema, Debug)]
 pub struct TitleBarSettingsContent {
+    /// Whether to show the title bar.
+    ///
+    /// Default: true
+    pub enabled: Option<bool>,
     /// Whether to show the branch icon beside branch switcher in the title bar.
     ///
     /// Default: false

--- a/docs/src/configuring-zed.md
+++ b/docs/src/configuring-zed.md
@@ -1287,6 +1287,22 @@ Each option controls displaying of a particular toolbar element. If all elements
 },
 ```
 
+## Title Bar
+
+- Description: Control the visibility of the title bar and its contents.
+- Setting: `title_bar`
+- Default:
+
+```json
+"title_bar": {
+  "enabled": true
+},
+```
+
+**Options**
+
+- `enabled` (`boolean`): When set to `false`, the title bar is not rendered.
+
 ## LSP
 
 - Description: Configuration for language servers.

--- a/docs/src/visual-customization.md
+++ b/docs/src/visual-customization.md
@@ -107,6 +107,7 @@ To disable this behavior use:
 ```json
   // Control which items are shown/hidden in the title bar
   "title_bar": {
+    "enabled": true,             // Show/hide the title bar
     "show_branch_icon": false,      // Show/hide branch icon beside branch switcher
     "show_branch_name": true,       // Show/hide branch name
     "show_project_items": true,     // Show/hide project host and name


### PR DESCRIPTION
## Summary
- allow title bar to be disabled via new `title_bar.enabled` option
- document title bar toggle in user guides and default settings

## Testing
- `cargo test -p title_bar` *(fails: build interrupted after long compile)*

------
https://chatgpt.com/codex/tasks/task_e_689a8e89c784832887930c29159f24a5