### PR TITLE
Add title bar visibility toggle

### DIFF
--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -353,6 +353,8 @@
   },
   // Titlebar related settings
   "title_bar": {
+    // Whether to show the title bar.
+    "visible": true,
     // Whether to show the branch icon beside branch switcher in the titlebar.
     "show_branch_icon": false,
     // Whether to show the branch name button in the titlebar.

--- a/crates/title_bar/src/title_bar.rs
+++ b/crates/title_bar/src/title_bar.rs
@@ -70,8 +70,12 @@ pub fn init(cx: &mut App) {
         let Some(window) = window else {
             return;
         };
-        let item = cx.new(|cx| TitleBar::new("title-bar", workspace, window, cx));
-        workspace.set_titlebar_item(item.into(), window, cx);
+        if TitleBarSettings::get_global(cx).visible {
+            let item = cx.new(|cx| TitleBar::new("title-bar", workspace, window, cx));
+            workspace.set_titlebar_item(Some(item.into()), window, cx);
+        } else {
+            workspace.set_titlebar_item(None, window, cx);
+        }
 
         #[cfg(not(target_os = "macos"))]
         workspace.register_action(|workspace, action: &OpenApplicationMenu, window, cx| {

--- a/crates/title_bar/src/title_bar_settings.rs
+++ b/crates/title_bar/src/title_bar_settings.rs
@@ -5,6 +5,7 @@ use settings::{Settings, SettingsSources};
 
 #[derive(Copy, Clone, Deserialize, Debug)]
 pub struct TitleBarSettings {
+    pub visible: bool,
     pub show_branch_icon: bool,
     pub show_onboarding_banner: bool,
     pub show_user_picture: bool,
@@ -16,6 +17,10 @@ pub struct TitleBarSettings {
 
 #[derive(Copy, Clone, Default, Serialize, Deserialize, JsonSchema, Debug)]
 pub struct TitleBarSettingsContent {
+    /// Whether to show the title bar.
+    ///
+    /// Default: true
+    pub visible: Option<bool>,
     /// Whether to show the branch icon beside branch switcher in the title bar.
     ///
     /// Default: false

--- a/crates/workspace/src/workspace.rs
+++ b/crates/workspace/src/workspace.rs
@@ -1992,8 +1992,13 @@ impl Workspace {
         &self.app_state.client
     }
 
-    pub fn set_titlebar_item(&mut self, item: AnyView, _: &mut Window, cx: &mut Context<Self>) {
-        self.titlebar_item = Some(item);
+    pub fn set_titlebar_item(
+        &mut self,
+        item: Option<AnyView>,
+        _: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        self.titlebar_item = item;
         cx.notify();
     }
 

--- a/docs/src/configuring-zed.md
+++ b/docs/src/configuring-zed.md
@@ -1287,6 +1287,16 @@ Each option controls displaying of a particular toolbar element. If all elements
 },
 ```
 
+## Title Bar Visibility
+
+- Description: Control the visibility of the title bar.
+- Setting: `title_bar.visible`
+- Default: `true`
+
+**Options**
+
+`boolean` values
+
 ## LSP
 
 - Description: Configuration for language servers.

--- a/docs/src/visual-customization.md
+++ b/docs/src/visual-customization.md
@@ -107,6 +107,7 @@ To disable this behavior use:
 ```json
   // Control which items are shown/hidden in the title bar
   "title_bar": {
+    "visible": true,            // Show/hide title bar entirely
     "show_branch_icon": false,      // Show/hide branch icon beside branch switcher
     "show_branch_name": true,       // Show/hide branch name
     "show_project_items": true,     // Show/hide project host and name


### PR DESCRIPTION
## Summary
- add `title_bar.visible` setting to allow hiding the title bar
- document title bar visibility setting in configuration docs
- respect the visibility flag when initializing workspace title bar

## Testing
- `cargo test -p title_bar -p workspace` *(fails: build in progress/aborted)*

------
https://chatgpt.com/codex/tasks/task_e_689a8ea1b3048328b4a2fdf2147dcbdf