### PR TITLE
Add initial Pijul integration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12220,6 +12220,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5be167a7af36ee22fe3115051bc51f6e6c7054c9348e28deb4f49bd6f705a315"
 
 [[package]]
+name = "pijul"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "gpui",
+ "workspace-hack",
+]
+
+[[package]]
+name = "pijul_ui"
+version = "0.1.0"
+dependencies = [
+ "fuzzy",
+ "gpui",
+ "picker",
+ "pijul",
+ "ui",
+ "util",
+ "workspace",
+ "workspace-hack",
+ "zed_actions",
+]
+
+[[package]]
 name = "pin-project"
 version = "1.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -20605,6 +20629,7 @@ dependencies = [
  "parking_lot",
  "paths",
  "picker",
+ "pijul_ui",
  "pretty_assertions",
  "profiling",
  "project",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -120,6 +120,8 @@ members = [
     "crates/panel",
     "crates/paths",
     "crates/picker",
+    "crates/pijul",
+    "crates/pijul_ui",
     "crates/prettier",
     "crates/project",
     "crates/project_panel",
@@ -314,6 +316,8 @@ inspector_ui = { path = "crates/inspector_ui" }
 install_cli = { path = "crates/install_cli" }
 jj = { path = "crates/jj" }
 jj_ui = { path = "crates/jj_ui" }
+pijul = { path = "crates/pijul" }
+pijul_ui = { path = "crates/pijul_ui" }
 journal = { path = "crates/journal" }
 language = { path = "crates/language" }
 language_extension = { path = "crates/language_extension" }

--- a/crates/pijul/Cargo.toml
+++ b/crates/pijul/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "pijul"
+version = "0.1.0"
+publish.workspace = true
+edition.workspace = true
+license = "GPL-3.0-or-later"
+
+[lints]
+workspace = true
+
+[lib]
+path = "src/pijul.rs"
+
+[dependencies]
+anyhow.workspace = true
+gpui.workspace = true
+workspace-hack.workspace = true

--- a/crates/pijul/LICENSE-GPL
+++ b/crates/pijul/LICENSE-GPL
@@ -1,0 +1,1 @@
+../../LICENSE-GPL

--- a/crates/pijul/src/pijul.rs
+++ b/crates/pijul/src/pijul.rs
@@ -1,0 +1,5 @@
+mod pijul_repository;
+mod pijul_store;
+
+pub use pijul_repository::*;
+pub use pijul_store::*;

--- a/crates/pijul/src/pijul_repository.rs
+++ b/crates/pijul/src/pijul_repository.rs
@@ -1,0 +1,54 @@
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+use anyhow::Result;
+use gpui::SharedString;
+
+#[derive(Debug, Clone)]
+pub struct Channel {
+    pub name: SharedString,
+}
+
+pub trait PijulRepository: Send + Sync {
+    fn list_channels(&self) -> Vec<Channel>;
+}
+
+pub struct RealPijulRepository {
+    cwd: PathBuf,
+}
+
+impl RealPijulRepository {
+    pub fn new(cwd: &Path) -> Result<Self> {
+        Ok(Self {
+            cwd: cwd.to_path_buf(),
+        })
+    }
+}
+
+impl PijulRepository for RealPijulRepository {
+    fn list_channels(&self) -> Vec<Channel> {
+        let output = Command::new("pijul")
+            .arg("channel")
+            .arg("list")
+            .current_dir(&self.cwd)
+            .output();
+
+        match output {
+            Ok(output) if output.status.success() => String::from_utf8_lossy(&output.stdout)
+                .lines()
+                .map(|line| Channel {
+                    name: line.trim().to_string().into(),
+                })
+                .collect(),
+            _ => Vec::new(),
+        }
+    }
+}
+
+pub struct FakePijulRepository {}
+
+impl PijulRepository for FakePijulRepository {
+    fn list_channels(&self) -> Vec<Channel> {
+        Vec::new()
+    }
+}

--- a/crates/pijul/src/pijul_store.rs
+++ b/crates/pijul/src/pijul_store.rs
@@ -1,0 +1,41 @@
+use std::path::Path;
+use std::sync::Arc;
+
+use gpui::{App, Entity, Global, prelude::*};
+
+use crate::{PijulRepository, RealPijulRepository};
+
+/// Note: We won't ultimately be storing the pijul store in a global, we're just doing this for exploration purposes.
+struct GlobalPijulStore(Entity<PijulStore>);
+
+impl Global for GlobalPijulStore {}
+
+pub struct PijulStore {
+    repository: Arc<dyn PijulRepository>,
+}
+
+impl PijulStore {
+    pub fn init_global(cx: &mut App) {
+        let Some(repository) = RealPijulRepository::new(Path::new(".")).ok() else {
+            return;
+        };
+
+        let repository = Arc::new(repository);
+        let pijul_store = cx.new(|cx| PijulStore::new(repository, cx));
+
+        cx.set_global(GlobalPijulStore(pijul_store));
+    }
+
+    pub fn try_global(cx: &App) -> Option<Entity<Self>> {
+        cx.try_global::<GlobalPijulStore>()
+            .map(|global| global.0.clone())
+    }
+
+    pub fn new(repository: Arc<dyn PijulRepository>, _cx: &mut Context<Self>) -> Self {
+        Self { repository }
+    }
+
+    pub fn repository(&self) -> &Arc<dyn PijulRepository> {
+        &self.repository
+    }
+}

--- a/crates/pijul_ui/Cargo.toml
+++ b/crates/pijul_ui/Cargo.toml
@@ -1,0 +1,23 @@
+[package]
+name = "pijul_ui"
+version = "0.1.0"
+publish.workspace = true
+edition.workspace = true
+license = "GPL-3.0-or-later"
+
+[lints]
+workspace = true
+
+[lib]
+path = "src/pijul_ui.rs"
+
+[dependencies]
+fuzzy.workspace = true
+gpui.workspace = true
+pijul.workspace = true
+picker.workspace = true
+ui.workspace = true
+util.workspace = true
+workspace-hack.workspace = true
+workspace.workspace = true
+zed_actions.workspace = true

--- a/crates/pijul_ui/LICENSE-GPL
+++ b/crates/pijul_ui/LICENSE-GPL
@@ -1,0 +1,1 @@
+../../LICENSE-GPL

--- a/crates/pijul_ui/src/channel_picker.rs
+++ b/crates/pijul_ui/src/channel_picker.rs
@@ -1,0 +1,198 @@
+use std::sync::Arc;
+
+use fuzzy::{StringMatchCandidate, match_strings};
+use gpui::{
+    App, DismissEvent, Entity, EventEmitter, FocusHandle, Focusable, Task, WeakEntity, Window,
+    prelude::*,
+};
+use picker::{Picker, PickerDelegate};
+use pijul::{Channel, PijulStore};
+use ui::{HighlightedLabel, ListItem, ListItemSpacing, prelude::*};
+use util::ResultExt as _;
+use workspace::{ModalView, Workspace};
+
+pub fn register(workspace: &mut Workspace) {
+    workspace.register_action(open);
+}
+
+fn open(
+    workspace: &mut Workspace,
+    _: &zed_actions::pijul::ChannelList,
+    window: &mut Window,
+    cx: &mut Context<Workspace>,
+) {
+    let Some(pijul_store) = PijulStore::try_global(cx) else {
+        return;
+    };
+
+    workspace.toggle_modal(window, cx, |window, cx| {
+        let delegate = ChannelPickerDelegate::new(cx.entity().downgrade(), pijul_store, cx);
+        ChannelPicker::new(delegate, window, cx)
+    });
+}
+
+pub struct ChannelPicker {
+    picker: Entity<Picker<ChannelPickerDelegate>>,
+}
+
+impl ChannelPicker {
+    pub fn new(
+        delegate: ChannelPickerDelegate,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) -> Self {
+        let picker = cx.new(|cx| Picker::uniform_list(delegate, window, cx));
+        Self { picker }
+    }
+}
+
+impl ModalView for ChannelPicker {}
+
+impl EventEmitter<DismissEvent> for ChannelPicker {}
+
+impl Focusable for ChannelPicker {
+    fn focus_handle(&self, cx: &App) -> FocusHandle {
+        self.picker.focus_handle(cx)
+    }
+}
+
+impl Render for ChannelPicker {
+    fn render(&mut self, _window: &mut Window, _cx: &mut Context<Self>) -> impl IntoElement {
+        v_flex().w(rems(34.)).child(self.picker.clone())
+    }
+}
+
+#[derive(Debug, Clone)]
+struct ChannelEntry {
+    channel: Channel,
+    positions: Vec<usize>,
+}
+
+pub struct ChannelPickerDelegate {
+    picker: WeakEntity<ChannelPicker>,
+    matches: Vec<ChannelEntry>,
+    all_channels: Vec<Channel>,
+    selected_index: usize,
+}
+
+impl ChannelPickerDelegate {
+    fn new(
+        picker: WeakEntity<ChannelPicker>,
+        pijul_store: Entity<PijulStore>,
+        cx: &mut Context<ChannelPicker>,
+    ) -> Self {
+        let channels = pijul_store.read(cx).repository().list_channels();
+
+        Self {
+            picker,
+            matches: Vec::new(),
+            all_channels: channels,
+            selected_index: 0,
+        }
+    }
+}
+
+impl PickerDelegate for ChannelPickerDelegate {
+    type ListItem = ListItem;
+
+    fn placeholder_text(&self, _window: &mut Window, _cx: &mut App) -> Arc<str> {
+        "Select Channel…".into()
+    }
+
+    fn match_count(&self) -> usize {
+        self.matches.len()
+    }
+
+    fn selected_index(&self) -> usize {
+        self.selected_index
+    }
+
+    fn set_selected_index(
+        &mut self,
+        ix: usize,
+        _window: &mut Window,
+        _cx: &mut Context<Picker<Self>>,
+    ) {
+        self.selected_index = ix;
+    }
+
+    fn update_matches(
+        &mut self,
+        query: String,
+        window: &mut Window,
+        cx: &mut Context<Picker<Self>>,
+    ) -> Task<()> {
+        let background = cx.background_executor().clone();
+        let all_channels = self.all_channels.clone();
+
+        cx.spawn_in(window, async move |this, cx| {
+            let matches = if query.is_empty() {
+                all_channels
+                    .into_iter()
+                    .map(|channel| ChannelEntry {
+                        channel,
+                        positions: Vec::new(),
+                    })
+                    .collect()
+            } else {
+                let candidates = all_channels
+                    .iter()
+                    .enumerate()
+                    .map(|(ix, channel)| StringMatchCandidate::new(ix, &channel.name))
+                    .collect::<Vec<_>>();
+                match_strings(
+                    &candidates,
+                    &query,
+                    false,
+                    true,
+                    100,
+                    &Default::default(),
+                    background,
+                )
+                .await
+                .into_iter()
+                .map(|mat| ChannelEntry {
+                    channel: all_channels[mat.candidate_id].clone(),
+                    positions: mat.positions,
+                })
+                .collect()
+            };
+
+            this.update(cx, |this, _cx| {
+                this.delegate.matches = matches;
+            })
+            .log_err();
+        })
+    }
+
+    fn confirm(&mut self, _secondary: bool, _window: &mut Window, _cx: &mut Context<Picker<Self>>) {
+        //
+    }
+
+    fn dismissed(&mut self, _window: &mut Window, cx: &mut Context<Picker<Self>>) {
+        self.picker
+            .update(cx, |_, cx| cx.emit(DismissEvent))
+            .log_err();
+    }
+
+    fn render_match(
+        &self,
+        ix: usize,
+        selected: bool,
+        _window: &mut Window,
+        _cx: &mut Context<Picker<Self>>,
+    ) -> Option<Self::ListItem> {
+        let entry = &self.matches[ix];
+
+        Some(
+            ListItem::new(ix)
+                .inset(true)
+                .spacing(ListItemSpacing::Sparse)
+                .toggle_state(selected)
+                .child(HighlightedLabel::new(
+                    entry.channel.name.clone(),
+                    entry.positions.clone(),
+                )),
+        )
+    }
+}

--- a/crates/pijul_ui/src/pijul_ui.rs
+++ b/crates/pijul_ui/src/pijul_ui.rs
@@ -1,0 +1,14 @@
+mod channel_picker;
+
+use gpui::App;
+use pijul::PijulStore;
+use workspace::Workspace;
+
+pub fn init(cx: &mut App) {
+    PijulStore::init_global(cx);
+
+    cx.observe_new(|workspace: &mut Workspace, _window, _cx| {
+        channel_picker::register(workspace);
+    })
+    .detach();
+}

--- a/crates/zed/Cargo.toml
+++ b/crates/zed/Cargo.toml
@@ -81,6 +81,7 @@ edit_prediction_button.workspace = true
 inspector_ui.workspace = true
 install_cli.workspace = true
 jj_ui.workspace = true
+pijul_ui.workspace = true
 journal.workspace = true
 language.workspace = true
 language_extension.workspace = true

--- a/crates/zed/src/main.rs
+++ b/crates/zed/src/main.rs
@@ -625,6 +625,7 @@ pub fn main() {
         collab_ui::init(&app_state, cx);
         git_ui::init(cx);
         jj_ui::init(cx);
+        pijul_ui::init(cx);
         feedback::init(cx);
         markdown_preview::init(cx);
         svg_preview::init(cx);

--- a/crates/zed_actions/src/lib.rs
+++ b/crates/zed_actions/src/lib.rs
@@ -192,6 +192,18 @@ pub mod jj {
     );
 }
 
+pub mod pijul {
+    use gpui::actions;
+
+    actions!(
+        pijul,
+        [
+            /// Opens the Pijul channel list.
+            ChannelList
+        ]
+    );
+}
+
 pub mod toast {
     use gpui::actions;
 


### PR DESCRIPTION
## Summary
- add Pijul repository abstraction and store
- expose Pijul channel picker UI and action
- wire Pijul UI into application startup

## Testing
- `cargo test -p pijul` *(fails: linker `clang` not found)*
- `cargo test -p pijul_ui` *(fails: linker `clang` not found)*
- `cargo check -p zed` *(fails: linker `clang` not found)*

------
https://chatgpt.com/codex/tasks/task_e_689c2518863083289da245a71548f727