### PR TITLE
Avoid redundant completion aside scroll rerenders

### DIFF
--- a/crates/editor/src/code_context_menus.rs
+++ b/crates/editor/src/code_context_menus.rs
@@ -1372,15 +1372,20 @@ impl CompletionsMenu {
         window: &mut Window,
         cx: &mut Context<Editor>,
     ) {
-        let mut offset = self.scroll_handle_aside.offset();
+        let previous_offset = self.scroll_handle_aside.offset();
+        let mut next_offset = previous_offset;
 
-        offset.y -= amount.pixels(
+        next_offset.y -= amount.pixels(
             window.line_height(),
             self.scroll_handle_aside.bounds().size.height - px(16.),
         ) / 2.0;
 
+        if next_offset == previous_offset {
+            return;
+        }
+
+        self.scroll_handle_aside.set_offset(next_offset);
         cx.notify();
-        self.scroll_handle_aside.set_offset(offset);
     }
 }
 


### PR DESCRIPTION
### Motivation
- Repeated no-op scroll steps in the completion-menu aside path were still causing UI notifications and rerenders during tight scroll input (e.g. key-repeat or simulated scrolling), contributing to unnecessary CPU usage.

### Description
- In `CompletionsMenu::scroll_aside` (`crates/editor/src/code_context_menus.rs`) compute `previous_offset` and `next_offset`, return early if unchanged, and only call `set_offset` and `cx.notify()` when the offset actually changes to avoid redundant work.

### Testing
- Ran `rustfmt crates/editor/src/code_context_menus.rs`, which completed successfully.
- Attempted `cargo test -p vim test_completion_menu_scroll_aside --profile release-fast --locked`, which began but did not complete in this environment due to lengthy workspace dependency compilation and was therefore not fully executed.
- Attempted `./script/clippy -p editor`, which started but did not complete in this environment for the same reason.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698c73845dbc8328a0090745cc512ae6)